### PR TITLE
Change the semantics of SEQ a little

### DIFF
--- a/src/nominal_lcf/semantics.fun
+++ b/src/nominal_lcf/semantics.fun
@@ -13,8 +13,9 @@ struct
           val beta = Spr.prepend us alpha
           val (beta', modulus) = Spr.probe (Spr.prepend us beta)
           val st' = mtac beta' st
+          val l = Int.max (0, !modulus - List.length us)
         in
-          rest (Spr.bite (!modulus) beta) st'
+          rest (Spr.bite l alpha) st'
         end)
       (fn _ => fn st => st)
       mtacs


### PR DESCRIPTION
This change is kind of nice; whereas previously, binding hyps was like pushing them onto a stack for the rest of the script, now it only pushes them onto the stack _for the duration_ of the first argument to SEQ.

So, now the behavior of the following scripts is different:

```
a, b, c <- (tac1; tac2);
tac3
```

vs

```
a, b, c <- tac1;
tac2;
tac3
```

Previously, [a,b,c] would in either case be consumed by tac1, tac2, tac3.

Now, in the former script, they are consumed by both (tac1, tac2), and
not by tac3; in the latter script, they are consumed only by tac1,
whereas tac2, tac3 do not consume those names.
