### PR TITLE
Update git command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ that you can implement in a sequential programming language like ML.
 ### Instructions
 
 ```
-git submodule init --recursive
+git submodule update --init --recursive
 rlwrap sml
 > CM.make "development.cm";
 ```


### PR DESCRIPTION
With git 2.12.1 the suggested `git submodule init --recursive` fails (`g s init` doesn't take `--recursive`) Using `g s init` and `g s update --recursive` succeeds but doesn't result in a working repository (I hit missing cmlib in one of the dependencies).

`g s update --init --recursive` seems to do the trick.