### PR TITLE
accumulate meta-info on subgoals

### DIFF
--- a/dependent_lcf.cm
+++ b/dependent_lcf.cm
@@ -5,12 +5,12 @@ Library
   signature LCF
   signature LCF_JUDGMENT
   signature LCF_TACTIC
-  signature LCF_LOG
+  signature LCF_TRACE
 
-  functor LoggedLcf
+  functor TracedLcf
   functor Lcf
-  functor LcfListLog
-  structure LcfBlankLog
+  functor LcfListTrace
+  structure LcfBlankTrace
   signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic

--- a/dependent_lcf.cm
+++ b/dependent_lcf.cm
@@ -5,8 +5,12 @@ Library
   signature LCF
   signature LCF_JUDGMENT
   signature LCF_TACTIC
+  signature LCF_LOG
 
+  functor LoggedLcf
   functor Lcf
+  functor LcfListLog
+  structure LcfBlankLog
   signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic

--- a/dependent_lcf.cm
+++ b/dependent_lcf.cm
@@ -6,8 +6,10 @@ Library
   signature LCF_JUDGMENT
   signature LCF_TACTIC
   signature LCF_TRACE
+  signature LCF_INFO
 
   functor TracedLcf
+  functor PlainLcf
   functor Lcf
   functor LcfListTrace
   structure LcfBlankTrace

--- a/dependent_lcf.cm
+++ b/dependent_lcf.cm
@@ -12,7 +12,6 @@ Library
   functor PlainLcf
   functor Lcf
   functor LcfListTrace
-  structure LcfBlankTrace
   signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic

--- a/dependent_lcf.mlb
+++ b/dependent_lcf.mlb
@@ -16,12 +16,12 @@ in
   signature LCF
   signature LCF_JUDGMENT
   signature LCF_TACTIC
-  signature LCF_LOG
+  signature LCF_TRACE
 
-  functor LoggedLcf
+  functor TracedLcf
   functor Lcf
-  functor LcfListLog
-  structure LcfBlankLog
+  functor LcfListTrace
+  structure LcfBlankTrace
   signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic

--- a/dependent_lcf.mlb
+++ b/dependent_lcf.mlb
@@ -17,6 +17,7 @@ in
   signature LCF_JUDGMENT
   signature LCF_TACTIC
   signature LCF_TRACE
+  signature LCF_INFO
 
   functor TracedLcf
   functor Lcf

--- a/dependent_lcf.mlb
+++ b/dependent_lcf.mlb
@@ -16,9 +16,13 @@ in
   signature LCF
   signature LCF_JUDGMENT
   signature LCF_TACTIC
-  signature LCF_TACTIC_MONAD
+  signature LCF_LOG
 
+  functor LoggedLcf
   functor Lcf
+  functor LcfListLog
+  structure LcfBlankLog
+  signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic
   structure LcfMonadBT

--- a/dependent_lcf.mlb
+++ b/dependent_lcf.mlb
@@ -22,7 +22,6 @@ in
   functor TracedLcf
   functor Lcf
   functor LcfListTrace
-  structure LcfBlankTrace
   signature LCF_TACTIC_MONAD
   signature LCF_TACTIC_KIT
   functor LcfTactic

--- a/example.sml
+++ b/example.sml
@@ -60,7 +60,7 @@ struct
   fun ren env (TRUE m) = TRUE (Tm.renameMetavars env m)
 end
 
-structure Lcf = LcfTactic (structure Lcf = LoggedLcf (structure L = Language and Log = LcfListLog (type e = string)) and J = Judgment and M = LcfMonadBT)
+structure Lcf = LcfTactic (structure Lcf = TracedLcf (structure L = Language and Tr = LcfListTrace (type e = string)) and J = Judgment and M = LcfMonadBT)
 
 
 signature REFINER =

--- a/example.sml
+++ b/example.sml
@@ -77,9 +77,11 @@ struct
   structure Tl = Lcf.Tl and V = Term.Metavar
 
   val |> = Lcf.|>
-  infix |>
+  val ::@ = Lcf.::@
+  infix 2 ::@
+  infix 3 |>
 
-  local structure Notation = TelescopeNotation (Tl) in open Notation infix >: end
+  local structure Notation = TelescopeNotation (Tl) in open Notation infix 4 >: end
 
   local
     val i = ref 0
@@ -106,8 +108,8 @@ struct
   fun SigmaIntro (TRUE P) =
     let
       val L.SIGMA $ [_ \ A, [x] \ B] = out P
-      val (goalA, holeA) = makeGoal (TRUE A)
-      val (goalB, holeB) = makeGoal (TRUE (substVar (holeA [], x) B))
+      val (goalA, holeA) = makeGoal (["SigmaI/proj1"] ::@ TRUE A)
+      val (goalB, holeB) = makeGoal (["SigmaI/proj2"] ::@ TRUE (substVar (holeA [], x) B))
       val pair = L.PAIR $$ [[] \ holeA [], [] \ holeB []]
     in
       Tl.empty >: goalA >: goalB
@@ -117,7 +119,7 @@ struct
   fun FooIntro (TRUE P) =
     let
       val L.FOO $ [_ \ A, _] = out P
-      val (goalA, holeA) = makeGoal (TRUE A)
+      val (goalA, holeA) = makeGoal (["FooI"] ::@ TRUE A)
     in
       Tl.empty >: goalA |> abtToAbs (holeA [])
     end
@@ -140,9 +142,13 @@ struct
     let
       val Lcf.|> (psi, vld) = Lcf.M.run (tac goal, fn _ => true)
       val xs \ m = outb vld
+      fun prettyGoal (Lcf.::@ (i, jdg)) =
+        "{[" ^ List.foldr (fn (x, s) => x ^ "." ^ s) "" i ^ "] @ " ^
+        Judgment.toString jdg
+         ^ "}"
     in
       print "\n\n";
-      print (ShowTel.toString Judgment.toString psi);
+      print (ShowTel.toString prettyGoal psi);
       print "\n--------------------------------\n";
       print (ShowTm.toString m);
       print "\n\n"

--- a/example.sml
+++ b/example.sml
@@ -60,14 +60,15 @@ struct
   fun ren env (TRUE m) = TRUE (Tm.renameMetavars env m)
 end
 
-structure Lcf = LcfTactic (structure Lcf = TracedLcf (structure L = Language and Tr = LcfListTrace (type e = string)) and J = Judgment and M = LcfMonadBT)
+structure Lcf = TracedLcf (structure L = Language and Tr = LcfListTrace (type e = string)) 
+structure Tac = LcfTactic (structure Lcf = Lcf and J = Judgment and M = LcfMonadBT)
 
 
 signature REFINER =
 sig
-  val UnitIntro : Lcf.jdg Lcf.rule
-  val SigmaIntro : Lcf.jdg Lcf.rule
-  val FooIntro : Lcf.jdg Lcf.rule
+  val UnitIntro : Tac.jdg Tac.rule
+  val SigmaIntro : Tac.jdg Tac.rule
+  val FooIntro : Tac.jdg Tac.rule
 end
 
 structure Refiner :> REFINER =
@@ -128,7 +129,7 @@ end
 structure Example =
 struct
   open L Refiner Judgment
-  open Lcf Term
+  open Tac Lcf Term
   structure ShowTm = PlainShowAbt (Term)
   structure ShowTel = TelescopeUtil (Tl)
   infix 5 $ \ then_ orelse_
@@ -140,7 +141,7 @@ struct
 
   fun run goal (tac : jdg tactic) =
     let
-      val Lcf.|> (psi, vld) = Lcf.M.run (tac goal, fn _ => true)
+      val Lcf.|> (psi, vld) = Tac.M.run (tac goal, fn _ => true)
       val xs \ m = outb vld
       fun prettyGoal (Lcf.::@ (i, jdg)) =
         "{[" ^ List.foldr (fn (x, s) => x ^ "." ^ s) "" i ^ "] @ " ^
@@ -168,11 +169,12 @@ struct
 
   (* to interact with the refiner, try commenting out some of the following lines *)
   val script =
-    Lcf.rule SigmaIntro
-      then_ try (Lcf.rule SigmaIntro)
-      then_ try (Lcf.rule UnitIntro)
-      then_ Lcf.rule FooIntro
-      then_ Lcf.rule UnitIntro
+    Tac.rule SigmaIntro
+      then_ try (Tac.rule SigmaIntro)
+      then_ try (Tac.rule UnitIntro)
+      then_ Tac.rule FooIntro
+      then_ Tac.rule UnitIntro
+      
 
   val _ = run (TRUE goal) script
 end

--- a/example.sml
+++ b/example.sml
@@ -60,7 +60,7 @@ struct
   fun ren env (TRUE m) = TRUE (Tm.renameMetavars env m)
 end
 
-structure Lcf = LcfTactic (structure Lcf = Lcf (Language) and J = Judgment and M = LcfMonadBT)
+structure Lcf = LcfTactic (structure Lcf = LoggedLcf (structure L = Language and Log = LcfListLog (type e = string)) and J = Judgment and M = LcfMonadBT)
 
 
 signature REFINER =

--- a/src/dependent_lcf/lcf.fun
+++ b/src/dependent_lcf/lcf.fun
@@ -2,37 +2,49 @@ functor Lcf (L : LCF_LANGUAGE) : LCF =
 struct
   structure L = L and Tl = Telescope (L.Var)
 
-  datatype 'a state = |> of 'a Tl.telescope * L.term
+  datatype 'a info = ::@ of string list * 'a
+  datatype 'a state = |> of 'a info Tl.telescope * L.term
 
+  infix 2 ::@ 
+  infix 3 |>
+
+  fun newInfo a = 
+    [] ::@ a
+
+  fun mapInfo f (i ::@ a) = 
+    i ::@ f a
+
+  fun projInfo (_ ::@ a) = 
+    a
+    
   type 'a isjdg =
      {sort : 'a -> L.sort,
       subst : L.env -> 'a -> 'a,
       ren : L.ren -> 'a -> 'a}
 
-  infix |>
-
+  
   fun liftJdg isjdg = isjdg
   
   fun map f (psi |> m) =
-    Tl.map f psi |> m
+    Tl.map (mapInfo f) psi |> m
 
-  fun ret {sort, subst, ren} jdg =
+  fun ret {sort, subst, ren} (a : 'a) =
     let
       val x = L.fresh ()
     in
-      Tl.singleton x jdg |> L.var x (sort jdg)
+      Tl.singleton x (newInfo a) |> L.var x (sort a)
     end
 
   fun 'a mul {sort, subst, ren} =
     let
       open Tl.ConsView
 
-      fun go (psi : 'a telescope, m : L.term, env : L.env, ppsi : 'a state telescope) =
+      fun go (psi : 'a info telescope, m : L.term, env : L.env, ppsi : 'a state info telescope) =
         case out ppsi of
            EMPTY => psi |> L.subst env m
-         | CONS (x, psix |> mx, ppsi') =>
+         | CONS (x, i ::@ (psix : 'a info telescope) |> mx, ppsi') =>
              let
-               val psix' = Tl.map (subst env) psix
+               val psix' = Tl.map (fn i' ::@ jdg => i @ i' ::@ subst env jdg) psix
                val psi' = Tl.append psi psix'
                val env' = L.Ctx.insert env x mx
              in

--- a/src/dependent_lcf/lcf.fun
+++ b/src/dependent_lcf/lcf.fun
@@ -1,11 +1,8 @@
-functor TracedLcf (structure L : LCF_LANGUAGE and Tr : LCF_TRACE) : LCF =
+functor Lcf (structure L : LCF_LANGUAGE and I : LCF_INFO) : LCF =
 struct
-  structure L = L and Tl = Telescope (L.Var) and Tr = Tr
+  structure L = L and Tl = Telescope (L.Var) and I = I
+  datatype 'a state = |> of 'a I.t Tl.telescope * L.term
 
-  datatype 'a traced = ::@ of Tr.t * 'a
-  datatype 'a state = |> of 'a traced Tl.telescope * L.term
-
-  infix 2 ::@ 
   infix 3 |>
 
   type 'a isjdg =
@@ -16,25 +13,26 @@ struct
   fun liftJdg isjdg = isjdg
   
   fun map f (psi |> m) =
-    Tl.map (fn (log ::@ x) => log ::@ f x) psi |> m
+    Tl.map (I.map f) psi |> m
 
   fun ret {sort, subst, ren} (a : 'a) =
     let
       val x = L.fresh ()
     in
-      Tl.singleton x (Tr.empty ::@ a) |> L.var x (sort a)
+      Tl.singleton x (I.ret a) |> L.var x (sort a)
     end
 
   fun 'a mul {sort, subst, ren} =
     let
       open Tl.ConsView
 
-      fun go (psi : 'a traced telescope, m : L.term, env : L.env, ppsi : 'a state traced telescope) =
+      fun go (psi : 'a I.t telescope, m : L.term, env : L.env, ppsi : 'a state I.t telescope) =
         case out ppsi of
            EMPTY => psi |> L.subst env m
-         | CONS (x, i ::@ (psix : 'a traced telescope) |> mx, ppsi') =>
+         | CONS (x, stx, ppsi') =>
              let
-               val psix' = Tl.map (fn i' ::@ jdg => Tr.append (i, i') ::@ subst env jdg) psix
+               val psix |> mx = I.run stx
+               val psix' = Tl.map (fn jdg => I.bind (stx, fn _ => I.map (subst env) jdg)) psix
                val psi' = Tl.append psi psix'
                val env' = L.Ctx.insert env x mx
              in
@@ -60,4 +58,57 @@ struct
   fun append _ = ()
 end
 
-functor Lcf (L : LCF_LANGUAGE) : LCF = TracedLcf (structure L = L and Tr = LcfBlankTrace)
+functor LcfTraceInfo (Tr : LCF_TRACE) : 
+sig
+  datatype 'a traced = ::@ of Tr.t * 'a
+  include LCF_INFO where type 'a t = 'a traced
+end = 
+struct
+  datatype 'a traced = ::@ of Tr.t * 'a
+  type 'a t = 'a traced
+
+  infix ::@
+
+  fun ret a = 
+    Tr.empty ::@ a
+
+  fun run (_ ::@ a) = 
+    a
+
+  fun map f (t ::@ a) = 
+    t ::@ f a
+
+  fun replace a (t ::@ _) = 
+    t ::@ a
+
+  fun bind (t ::@ a, k) = 
+    let
+      val t' ::@ b = k a
+    in
+      Tr.append (t, t') ::@ b
+    end
+end
+
+structure LcfIdentityInfo : LCF_INFO = 
+struct
+  type 'a t = 'a
+  fun ret a = a
+  fun run a = a
+  fun map f = f
+  fun bind (a, k) = k a
+  fun replace a _ = a
+end
+
+functor PlainLcf (L : LCF_LANGUAGE) : PLAIN_LCF = Lcf (structure L = L and I = LcfIdentityInfo)
+
+functor TracedLcf (structure L : LCF_LANGUAGE and Tr : LCF_TRACE) : TRACED_LCF = 
+struct
+  local
+    structure TrI = LcfTraceInfo (Tr)
+    structure X = Lcf (structure L = L and I = TrI)
+  in
+    open X
+    type trace = Tr.t
+    datatype traced = datatype TrI.traced
+  end
+end

--- a/src/dependent_lcf/lcf.fun
+++ b/src/dependent_lcf/lcf.fun
@@ -51,13 +51,6 @@ struct
   val append = op@
 end
 
-structure LcfBlankTrace :> LCF_TRACE = 
-struct
-  type t = unit
-  val empty = ()
-  fun append _ = ()
-end
-
 functor LcfTraceInfo (Tr : LCF_TRACE) : 
 sig
   datatype 'a traced = ::@ of Tr.t * 'a

--- a/src/dependent_lcf/lcf.fun
+++ b/src/dependent_lcf/lcf.fun
@@ -1,9 +1,9 @@
-functor LoggedLcf (structure L : LCF_LANGUAGE and Log : LCF_LOG) : LCF =
+functor TracedLcf (structure L : LCF_LANGUAGE and Tr : LCF_TRACE) : LCF =
 struct
-  structure L = L and Tl = Telescope (L.Var) and Log = Log
+  structure L = L and Tl = Telescope (L.Var) and Tr = Tr
 
-  datatype 'a info = ::@ of Log.t * 'a
-  datatype 'a state = |> of 'a info Tl.telescope * L.term
+  datatype 'a traced = ::@ of Tr.t * 'a
+  datatype 'a state = |> of 'a traced Tl.telescope * L.term
 
   infix 2 ::@ 
   infix 3 |>
@@ -22,19 +22,19 @@ struct
     let
       val x = L.fresh ()
     in
-      Tl.singleton x (Log.empty ::@ a) |> L.var x (sort a)
+      Tl.singleton x (Tr.empty ::@ a) |> L.var x (sort a)
     end
 
   fun 'a mul {sort, subst, ren} =
     let
       open Tl.ConsView
 
-      fun go (psi : 'a info telescope, m : L.term, env : L.env, ppsi : 'a state info telescope) =
+      fun go (psi : 'a traced telescope, m : L.term, env : L.env, ppsi : 'a state traced telescope) =
         case out ppsi of
            EMPTY => psi |> L.subst env m
-         | CONS (x, i ::@ (psix : 'a info telescope) |> mx, ppsi') =>
+         | CONS (x, i ::@ (psix : 'a traced telescope) |> mx, ppsi') =>
              let
-               val psix' = Tl.map (fn i' ::@ jdg => Log.append (i, i') ::@ subst env jdg) psix
+               val psix' = Tl.map (fn i' ::@ jdg => Tr.append (i, i') ::@ subst env jdg) psix
                val psi' = Tl.append psi psix'
                val env' = L.Ctx.insert env x mx
              in
@@ -46,18 +46,18 @@ struct
     end
 end
 
-functor LcfListLog (type e) : LCF_LOG = 
+functor LcfListTrace (type e) : LCF_TRACE = 
 struct
   type t = e list
   val empty = []
   val append = op@
 end
 
-structure LcfBlankLog :> LCF_LOG = 
+structure LcfBlankTrace :> LCF_TRACE = 
 struct
   type t = unit
   val empty = ()
   fun append _ = ()
 end
 
-functor Lcf (L : LCF_LANGUAGE) : LCF = LoggedLcf (structure L = L and Log = LcfBlankLog)
+functor Lcf (L : LCF_LANGUAGE) : LCF = TracedLcf (structure L = L and Tr = LcfBlankTrace)

--- a/src/dependent_lcf/lcf.fun
+++ b/src/dependent_lcf/lcf.fun
@@ -1,38 +1,28 @@
-functor Lcf (L : LCF_LANGUAGE) : LCF =
+functor LoggedLcf (structure L : LCF_LANGUAGE and Log : LCF_LOG) : LCF =
 struct
-  structure L = L and Tl = Telescope (L.Var)
+  structure L = L and Tl = Telescope (L.Var) and Log = Log
 
-  datatype 'a info = ::@ of string list * 'a
+  datatype 'a info = ::@ of Log.t * 'a
   datatype 'a state = |> of 'a info Tl.telescope * L.term
 
   infix 2 ::@ 
   infix 3 |>
 
-  fun newInfo a = 
-    [] ::@ a
-
-  fun mapInfo f (i ::@ a) = 
-    i ::@ f a
-
-  fun projInfo (_ ::@ a) = 
-    a
-    
   type 'a isjdg =
      {sort : 'a -> L.sort,
       subst : L.env -> 'a -> 'a,
       ren : L.ren -> 'a -> 'a}
 
-  
   fun liftJdg isjdg = isjdg
   
   fun map f (psi |> m) =
-    Tl.map (mapInfo f) psi |> m
+    Tl.map (fn (log ::@ x) => log ::@ f x) psi |> m
 
   fun ret {sort, subst, ren} (a : 'a) =
     let
       val x = L.fresh ()
     in
-      Tl.singleton x (newInfo a) |> L.var x (sort a)
+      Tl.singleton x (Log.empty ::@ a) |> L.var x (sort a)
     end
 
   fun 'a mul {sort, subst, ren} =
@@ -44,7 +34,7 @@ struct
            EMPTY => psi |> L.subst env m
          | CONS (x, i ::@ (psix : 'a info telescope) |> mx, ppsi') =>
              let
-               val psix' = Tl.map (fn i' ::@ jdg => i @ i' ::@ subst env jdg) psix
+               val psix' = Tl.map (fn i' ::@ jdg => Log.append (i, i') ::@ subst env jdg) psix
                val psi' = Tl.append psi psix'
                val env' = L.Ctx.insert env x mx
              in
@@ -55,3 +45,19 @@ struct
         go (Tl.empty, m, L.Ctx.empty, psi)
     end
 end
+
+functor LcfListLog (type e) : LCF_LOG = 
+struct
+  type t = e list
+  val empty = []
+  val append = op@
+end
+
+structure LcfBlankLog :> LCF_LOG = 
+struct
+  type t = unit
+  val empty = ()
+  fun append _ = ()
+end
+
+functor Lcf (L : LCF_LANGUAGE) : LCF = LoggedLcf (structure L = L and Log = LcfBlankLog)

--- a/src/dependent_lcf/lcf.sig
+++ b/src/dependent_lcf/lcf.sig
@@ -3,7 +3,13 @@ sig
   structure L : LCF_LANGUAGE
   structure Tl : TELESCOPE where type Label.t = L.var
 
-  datatype 'a state = |> of 'a Tl.telescope * L.term
+  datatype 'a info = ::@ of string list * 'a
+
+  val newInfo : 'a -> 'a info
+  val mapInfo : ('a -> 'b) -> 'a info -> 'b info
+  val projInfo : 'a info -> 'a
+  
+  datatype 'a state = |> of 'a info Tl.telescope * L.term
 
   type 'a isjdg =
      {sort : 'a -> L.sort,

--- a/src/dependent_lcf/lcf.sig
+++ b/src/dependent_lcf/lcf.sig
@@ -1,18 +1,18 @@
-signature LCF_LOG = 
+signature LCF_TRACE = 
 sig
-    type t
-    val empty : t
-    val append : t * t -> t
+  type t
+  val empty : t
+  val append : t * t -> t
 end
 
 signature LCF =
 sig
   structure L : LCF_LANGUAGE
   structure Tl : TELESCOPE where type Label.t = L.var
-  structure Log : LCF_LOG
+  structure Tr : LCF_TRACE
 
-  datatype 'a info = ::@ of Log.t * 'a
-  datatype 'a state = |> of 'a info Tl.telescope * L.term
+  datatype 'a traced = ::@ of Tr.t * 'a
+  datatype 'a state = |> of 'a traced Tl.telescope * L.term
 
   type 'a isjdg =
      {sort : 'a -> L.sort,

--- a/src/dependent_lcf/lcf.sig
+++ b/src/dependent_lcf/lcf.sig
@@ -1,14 +1,17 @@
+signature LCF_LOG = 
+sig
+    type t
+    val empty : t
+    val append : t * t -> t
+end
+
 signature LCF =
 sig
   structure L : LCF_LANGUAGE
   structure Tl : TELESCOPE where type Label.t = L.var
+  structure Log : LCF_LOG
 
-  datatype 'a info = ::@ of string list * 'a
-
-  val newInfo : 'a -> 'a info
-  val mapInfo : ('a -> 'b) -> 'a info -> 'b info
-  val projInfo : 'a info -> 'a
-  
+  datatype 'a info = ::@ of Log.t * 'a
   datatype 'a state = |> of 'a info Tl.telescope * L.term
 
   type 'a isjdg =

--- a/src/dependent_lcf/lcf.sig
+++ b/src/dependent_lcf/lcf.sig
@@ -5,14 +5,23 @@ sig
   val append : t * t -> t
 end
 
+signature LCF_INFO = 
+sig
+  type 'a t
+  val ret : 'a -> 'a t
+  val run : 'a t -> 'a
+  val map : ('a -> 'b) -> 'a t -> 'b t
+  val bind : 'a t * ('a -> 'b t) -> 'b t
+  val replace : 'b -> 'a t -> 'b t
+end
+
 signature LCF =
 sig
   structure L : LCF_LANGUAGE
   structure Tl : TELESCOPE where type Label.t = L.var
-  structure Tr : LCF_TRACE
+  structure I : LCF_INFO
 
-  datatype 'a traced = ::@ of Tr.t * 'a
-  datatype 'a state = |> of 'a traced Tl.telescope * L.term
+  datatype 'a state = |> of 'a I.t Tl.telescope * L.term
 
   type 'a isjdg =
      {sort : 'a -> L.sort,
@@ -22,6 +31,16 @@ sig
   val map : ('a -> 'b) -> 'a state -> 'b state
   val ret : 'a isjdg -> 'a -> 'a state
   val mul : 'a isjdg -> 'a state state -> 'a state
+end
+
+signature PLAIN_LCF = 
+  LCF where type 'a I.t = 'a
+
+signature TRACED_LCF = 
+sig
+  type trace
+  datatype 'a traced = ::@ of trace * 'a
+  include LCF where type 'a I.t = 'a traced
 end
 
 signature LCF_JUDGMENT =

--- a/src/dependent_lcf/tactic.fun
+++ b/src/dependent_lcf/tactic.fun
@@ -85,10 +85,10 @@ struct
 
   infix >>-*
 
-  fun each (ts : jdg tactic list) ((psi : jdg info Tl.telescope) |> vl) : jdg state state M.m =
+  fun each (ts : jdg tactic list) (psi |> vl) : jdg state state M.m =
     let
       open Tl.ConsView
-      fun go (r : jdg state info telescope) =
+      fun go (r : jdg state traced telescope) =
         fn (_, EMPTY) => M.ret r
          | (t :: ts, CONS (x, log ::@ jdg, psi)) =>
              wrap t jdg >>-* (fn tjdg =>
@@ -103,7 +103,7 @@ struct
   fun eachSeq (ts : jdg tactic list) (psi |> vl) =
     let
       open Tl.ConsView
-      fun go rho (r : jdg state info telescope) =
+      fun go rho (r : jdg state traced telescope) =
         fn (_, EMPTY) => M.ret r
          | (t :: ts, CONS (x, log ::@ jdg, psi)) =>
             wrap t (J.subst rho jdg) >>-*
@@ -199,11 +199,10 @@ struct
   exception Progress
   exception Complete
 
-
   fun progress t (jdg : jdg) =
     t jdg >>-* (fn st as (psi |> vl) =>
       let
-        val psi' = Tl.singleton (L.fresh ()) (Log.empty ::@ jdg)
+        val psi' = Tl.singleton (L.fresh ()) (Tr.empty ::@ jdg)
       in
         case unifySubtelescope (psi', psi) of
            SOME _ => M.throw Progress

--- a/src/dependent_lcf/tactic.fun
+++ b/src/dependent_lcf/tactic.fun
@@ -88,13 +88,13 @@ struct
   fun each (ts : jdg tactic list) (psi |> vl) : jdg state state M.m =
     let
       open Tl.ConsView
-      fun go (r : jdg state traced telescope) =
+      fun go (r : jdg state I.t telescope) =
         fn (_, EMPTY) => M.ret r
-         | (t :: ts, CONS (x, log ::@ jdg, psi)) =>
-             wrap t jdg >>-* (fn tjdg =>
-               go (Tl.snoc r x (log ::@ tjdg)) (ts, out psi))
-         | ([], CONS (x, log ::@ jdg, psi)) => 
-             go (Tl.snoc r x (log ::@ ret isjdg jdg)) ([], out psi)
+         | (t :: ts, CONS (x, jdg, psi)) =>
+             wrap t (I.run jdg) >>-* (fn tjdg =>
+               go (Tl.snoc r x (I.replace tjdg jdg)) (ts, out psi))
+         | ([], CONS (x, jdg, psi)) => 
+             go (Tl.snoc r x (I.map (ret isjdg) jdg)) ([], out psi)
     in
       M.shortcircuit (go Tl.empty (ts, out psi), Tl.isEmpty, fn psi => M.ret (psi |> vl))
     end
@@ -103,18 +103,18 @@ struct
   fun eachSeq (ts : jdg tactic list) (psi |> vl) =
     let
       open Tl.ConsView
-      fun go rho (r : jdg state traced telescope) =
+      fun go rho (r : jdg state I.t telescope) =
         fn (_, EMPTY) => M.ret r
-         | (t :: ts, CONS (x, log ::@ jdg, psi)) =>
-            wrap t (J.subst rho jdg) >>-*
+         | (t :: ts, CONS (x, jdg, psi)) =>
+            wrap t (J.subst rho (I.run jdg)) >>-*
               (fn tjdg as (psix |> vlx) =>
                let
                  val rho' = L.Ctx.insert rho x vlx
                in
-                 go rho' (Tl.snoc r x (log ::@ tjdg)) (ts, out psi)
+                 go rho' (Tl.snoc r x (I.replace tjdg jdg)) (ts, out psi)
                end)
-         | ([], CONS (x, log ::@ jdg, psi)) => 
-            go rho (Tl.snoc r x (log ::@ ret isjdg jdg)) ([], out psi)
+         | ([], CONS (x, jdg, psi)) => 
+            go rho (Tl.snoc r x (I.map (ret isjdg) jdg)) ([], out psi)
     in
       M.shortcircuit (go L.Ctx.empty Tl.empty (ts, out psi), Tl.isEmpty, fn psi => M.ret (psi |> vl))
     end
@@ -177,8 +177,8 @@ struct
     fun unifySubtelescopeAux (env1, env2) (psi1, psi2) =
       case (out psi1, out psi2) of
          (EMPTY, _) => SOME (env1, env2)
-       | (CONS (x1, _ ::@ jdg1, psi1'), CONS (x2, _ ::@ jdg2, psi2')) =>
-            if J.eq (J.ren env1 jdg1, J.ren env2 jdg2) then
+       | (CONS (x1, jdg1, psi1'), CONS (x2, jdg2, psi2')) =>
+            if J.eq (J.ren env1 (I.run jdg1), J.ren env2 (I.run jdg2)) then
               let
                 val y = L.fresh ()
                 val env1y = L.Ctx.insert env1 x1 y
@@ -202,7 +202,7 @@ struct
   fun progress t (jdg : jdg) =
     t jdg >>-* (fn st as (psi |> vl) =>
       let
-        val psi' = Tl.singleton (L.fresh ()) (Tr.empty ::@ jdg)
+        val psi' = Tl.singleton (L.fresh ()) (I.ret jdg)
       in
         case unifySubtelescope (psi', psi) of
            SOME _ => M.throw Progress


### PR DESCRIPTION
@favonia This adds some kind of log or trace to each goal in the LCF proof state.  The idea is that rules can give a breadcrumb to each of their goals, and then when you read the proof state, you can actually trace the exact provenience of each goal. See `example.sml` for an example of this...

Does this sound useful to you?

This resolves #40 